### PR TITLE
specifies the imported class explicitly with the python3 normalization

### DIFF
--- a/pyFarnell/__init__.py
+++ b/pyFarnell/__init__.py
@@ -1,1 +1,1 @@
-from pyFarnell import *
+from .pyFarnell import Farnell

--- a/pyFarnell/pyFarnell.py
+++ b/pyFarnell/pyFarnell.py
@@ -16,6 +16,7 @@ class Farnell():
             raise Exception("Contact Farnell representative to create an accout for \'Product Search API: Standard' product for you.")
 
         self.apiKey = apiKey
+        self.region = region
         self.base_url = 'https://api.element14.com/catalog/products'
 
     def get_part_by_number(self, partNum):
@@ -31,7 +32,7 @@ class Farnell():
         params = {
                    'callInfo.responseDataFormat': 'JSON',
                    'term': 'id:' + str(partNum),
-                   'storeInfo.id': 'sk.farnell.com',
+                   'storeInfo.id': self.region,
                    'callInfo.apiKey': self.apiKey,
                  }
         r = requests.get(self.base_url, params = params)

--- a/pyFarnell/pyFarnell.py
+++ b/pyFarnell/pyFarnell.py
@@ -19,7 +19,7 @@ class Farnell():
         self.region = region
         self.base_url = 'https://api.element14.com/catalog/products'
 
-    def get_part_by_number(self, partNum):
+    def get_part_by_number(self, partNum, part = {}):
         """Gets part information
 
         :param partNum: Farnells part order number
@@ -35,6 +35,7 @@ class Farnell():
                    'storeInfo.id': self.region,
                    'callInfo.apiKey': self.apiKey,
                  }
+        params.update(part)
         r = requests.get(self.base_url, params = params)
         if r.status_code != 200:
             raise Exception("Developer apiKey not active - contact Farnell representative to activate account for \'Product Search API: Standard' product - API key " + str(self.apiKey))


### PR DESCRIPTION
Hello @hecko and thank you for your work !

I have tested your [example](https://github.com/hecko/pyFarnell#use-example) for the version 3 of Python. My result is different:
```bash
AttributeError: module 'pyFarnell' has no attribute 'Farnell'
```
According to the [answer-4142178](https://stackoverflow.com/questions/4142151/how-to-import-the-class-within-the-same-directory-or-sub-directory#answer-4142178) from the question [How to import the class within the same directory or sub directory](https://stackoverflow.com/questions/4142151/how-to-import-the-class-within-the-same-directory-or-sub-directory), we can solve this python 3's error if we prefix the module name with a '.'.

Accodding to [sunset-python-2](https://www.python.org/doc/sunset-python-2), from the January 1, 2020,  we should upgrade to Python 3 as soon as you can.

That why my pull request only consider the version 3 of python.